### PR TITLE
feat(errors): rethrow errors that are nested in an object

### DIFF
--- a/events.js
+++ b/events.js
@@ -57,6 +57,8 @@ EventEmitter.prototype.emit = function(type) {
       er = arguments[1];
       if (er instanceof Error) {
         throw er; // Unhandled 'error' event
+      } else if (er.error instanceof Error) {
+        throw er.error; // Unhandled 'error' event
       } else {
         // At least give some kind of context to the user
         var err = new Error('Uncaught, unspecified "error" event. (' + er + ')');

--- a/tests/errors.js
+++ b/tests/errors.js
@@ -1,0 +1,37 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var assert = require('assert');
+var EventEmitter = require('../');
+
+var e = new EventEmitter();
+
+assert.throws(function () {
+  e.emit('error', new Error('direct error'));
+}, new Error('direct error'));
+
+assert.throws(function () {
+  e.emit('error', { error: new Error('nested error') });
+}, new Error('nested error'));
+
+assert.throws(function () {
+  e.emit('error', { error: 'just a string' });
+}, new Error('Uncaught, unspecified "error" event. ([object Object])'));

--- a/tests/index.js
+++ b/tests/index.js
@@ -34,3 +34,4 @@ require('./set-max-listeners-side-effects.js');
 require('./subclass.js');
 require('./remove-all-listeners.js');
 require('./remove-listeners.js');
+require('./errors');


### PR DESCRIPTION
In InstantSearch and the helper we use `.emit('error', { error: new Error() })` in some cases. This can be fixed in events, or in the helper/instantsearch. As those two optoins are open and changing inside instantsearch could be a breakign change